### PR TITLE
Report git version with library_version

### DIFF
--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -275,10 +275,15 @@ static int update_variables()
   return ( reset ? UPDATE_RESET : 0 ) | ( old_scaled != state.scaled ? UPDATE_AV : 0 );
 }
 
+#define VERSION "1.0a"
+static char version[] = VERSION " .......";
+
 void retro_get_system_info( struct retro_system_info* info )
 {
+  memcpy(version + sizeof(VERSION), eo_githash, 7);
+
   info->library_name = "EightyOne";
-  info->library_version = "1.0a";
+  info->library_version = version;
   info->need_fullpath = false;
   info->block_extract = false;
   info->valid_extensions = "p|tzx|t81";


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.