### PR TITLE
Fix multiple definition error when -fno-common

### DIFF
--- a/src/coreopt.c
+++ b/src/coreopt.c
@@ -7,7 +7,7 @@
 
 #include <gamedb/db.inl>
 
-retro_log_printf_t log_cb;
+extern retro_log_printf_t log_cb;
 
 static int getindex( const char* options, const char* value )
 {


### PR DESCRIPTION
In some system when `-fno-common` is the default gcc flag, it throws the following error:

```
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: ./src/libretro.o:(.data.rel.local+0x0): multiple definition of `log_cb'; ./src/coreopt.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
```
To fix it, I add `extern` in the definition.