### PR TITLE
Fix keyboard in small or none border and reorder sound options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The only core option available on the frontend is:
 
 * Tape Fast Load (enabled|disabled): Instantly loads files if enabled, or disabled it to see the moving horizontal lines while the game loads
 * 8K-16K Contents (ROM shadow|RAM|dK'tronics 4K Graphics ROM + 4K RAM): Selects the contents of memory addresses between 8192 and 16383, a shadow copy of the ROM, 8K of RAM, or [dK'tronics 4K ROM plus 4K of RAM](http://www.fruitcake.plus.com/Sinclair/ZX81/Chroma/ChromaInterface_Software_CharacterSetROM.htm)
+* Size Video Border (normal|small|none): Select the size of video border
 * High Resolution (auto|none|WRX): Enables WRX high resolution
 * Emulate Chroma 81 (auto|disabled|enabled): Enable the [Chroma 81](http://www.fruitcake.plus.com/Sinclair/ZX81/Chroma/ChromaInterface.htm) interface
 * Video Presets (clean|tv|noisy): Change how the video is emulated (if Chroma 81 is enabled, the video is set to "clean" regardless of this option)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The only core option available on the frontend is:
 * High Resolution (auto|none|WRX): Enables WRX high resolution
 * Emulate Chroma 81 (auto|disabled|enabled): Enable the [Chroma 81](http://www.fruitcake.plus.com/Sinclair/ZX81/Chroma/ChromaInterface.htm) interface
 * Video Presets (clean|tv|noisy): Change how the video is emulated (if Chroma 81 is enabled, the video is set to "clean" regardless of this option)
-* Sound emulation (auto|none|Zon X-81): Enables sound emulation
+* Sound emulation (none|auto|Zon X-81): Enables sound emulation
 * Joypad button (up, down, left, right, a, b, x, y, l, r, l2, r2) mappings (auto|default|new line|shift|space|.|0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z): Maps a joypad button to a keyboard key, defaults are the cursor keys for the directional pad and '0' to all the other buttons
 * Transparent Keyboard Overlay (enabled|disabled): If the keyboard overlay is transparent or opaque
 * Time to Release Key in ms (500|1000|100|300): How many milliseconds to wait before releasing the key pressed using the keyboard overlay

--- a/src/eo.h
+++ b/src/eo.h
@@ -42,6 +42,7 @@ typedef struct
   int     HiRes;
   int     SoundCard;
   bool    Chroma81;
+  int     BorderSize;
   
   int Brightness; /* 0 -> 255 */
   int Contrast;   /* 0 -> 255 */

--- a/src/eo.h
+++ b/src/eo.h
@@ -22,6 +22,7 @@
 #define RAMPACK96   8
 
 #define AY_TYPE_DISABLED 0
+#define AY_TYPE_ENABLED  1
 
 #define LOWRAM_ROMSHADOW 0
 #define LOWRAM_8KRAM     1

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -215,13 +215,22 @@ static int update_variables()
     reset = reset || state.cfg.HiRes != hires[ option ];
     state.cfg.HiRes = hires[ option ];
   }
+
+
+  {
+    static int borderSize[] = { BORDERNORMAL, BORDERSMALL, BORDERNONE };
+    int border_size = coreopt(env_cb, core_vars, state.sha1, "81_border_size", NULL);
+    border_size += border_size < 0;
+    reset = reset || state.cfg.BorderSize != borderSize[ border_size ];
+    state.cfg.BorderSize = borderSize[ border_size ];    
+  }
   
   {
     static int sound[] = { AY_TYPE_DISABLED, AY_TYPE_ZONX };
     int option = coreopt( env_cb, core_vars, state.sha1, "81_sound", NULL );
     option += option < 0;
-    reset = reset || state.cfg.SoundCard != sound[ option ];
-    state.cfg.SoundCard = sound[ option ];
+    reset = reset || state.cfg.SoundCard != sound[ option + 1];
+    state.cfg.SoundCard = sound[ option + 1];
   }
   
   state.transp = coreopt( env_cb, core_vars, state.sha1, "81_keybovl_transp", NULL ) != 1;
@@ -390,6 +399,7 @@ bool retro_load_game( const struct retro_game_info* info )
   state.cfg.HiRes = HIRESDISABLED;
   state.cfg.SoundCard = AY_TYPE_DISABLED;
   state.cfg.Chroma81 = 0;
+  state.cfg.BorderSize = BORDERNORMAL;
   
   state.scaled = -1;
   TZXFile.AddTextBlock( "" ); // prevent a crash if the user does a LOAD ""
@@ -490,18 +500,22 @@ void retro_run( void )
   int border_size = coreopt(env_cb, core_vars, state.sha1, "81_border_size", NULL);
   border_size += border_size < 0;
 
+  int TVPKEYB = 1040;
   if (border_size == 1)
-  {	
-	WinL=WinLSM; WinR=WinRSM; WinT=WinTSM; WinB=WinBSM;
+  {
+    TVPKEYB = 420;
+    WinL=WinLSM; WinR=WinRSM; WinT=WinTSM; WinB=WinBSM;
   }
   else if (border_size == 2)
   {
-	WinL=WinLBN; WinR=WinRBN; WinT=WinTBN; WinB=WinBBN;
+    TVPKEYB = 500;
+    WinL=WinLBN; WinR=WinRBN; WinT=WinTBN; WinB=WinBBN;
   }
-  
-  uint16_t* fb = TVFB + WinL + WinT * TVP / 2;  
+
+  uint16_t* fb = TVFB + WinL + WinT * TVP / 2;
+  uint16_t* fbKeyb = TVFB + WinL + WinT * TVPKEYB / 2;  
   eo_tick();
-  keybovl_update( input_state_cb, state.devices, fb, TVP / 2, state.transp, state.scaled, state.ms, 20 );
+  keybovl_update( input_state_cb, state.devices, fbKeyb, TVP / 2, state.transp, state.scaled, state.ms, 20 );
   video_cb( (void*)fb, WinR - WinL, WinB - WinT, TVP );
 }
 

--- a/src/libretro.cpp
+++ b/src/libretro.cpp
@@ -84,7 +84,7 @@ static const struct retro_variable core_vars[] =
   { "81_highres",        "High Resolution; auto|none|WRX" },
   { "81_chroma_81",      "Emulate Chroma 81; auto|disabled|enabled" },
   { "81_video_presets",  "Video Presets; clean|tv|noisy" },
-  { "81_sound",          "Sound emulation; auto|none|Zon X-81" },
+  { "81_sound",          "Sound emulation; none|auto|Zon X-81" },
   { "81_joypad_left",    "Joypad Left mapping; " ZX81KEYS },
   { "81_joypad_right",   "Joypad Right mapping; " ZX81KEYS },
   { "81_joypad_up",      "Joypad Up mapping; " ZX81KEYS },
@@ -226,11 +226,11 @@ static int update_variables()
   }
   
   {
-    static int sound[] = { AY_TYPE_DISABLED, AY_TYPE_ZONX };
+    static int sound[] = { AY_TYPE_DISABLED, AY_TYPE_ENABLED, AY_TYPE_ZONX };
     int option = coreopt( env_cb, core_vars, state.sha1, "81_sound", NULL );
     option += option < 0;
-    reset = reset || state.cfg.SoundCard != sound[ option + 1];
-    state.cfg.SoundCard = sound[ option + 1];
+    reset = reset || state.cfg.SoundCard != sound[ option ];
+    state.cfg.SoundCard = sound[ option ];
   }
   
   state.transp = coreopt( env_cb, core_vars, state.sha1, "81_keybovl_transp", NULL ) != 1;


### PR DESCRIPTION
- Updated README file for new border option.

- Keyboard setting so that when using the border small or none keys are not hidden.

|  | Small border | None border |
|--------------------|--------------------|--------------------|
| Before | ![Abduxion-221012-220912](https://user-images.githubusercontent.com/6243712/195454737-62b3ceef-5bc6-469e-b570-4076597a4aec.png) | ![Abduxion-221012-220933](https://user-images.githubusercontent.com/6243712/195454761-c912f09c-162d-4bfc-b6de-cce5f86cb6fe.png) |
| After | ![Abduxion-221012-220717](https://user-images.githubusercontent.com/6243712/195454829-8961d280-5c4b-4b9f-8cbb-97c0003cf288.png) | ![Abduxion-221012-220623](https://user-images.githubusercontent.com/6243712/195454852-0d6273d7-3565-48ae-ba00-fb036b4df1ca.png) |

- Change in the order of the sound options, before it only sounded with the none option. Updated the README file with this change

| Before | After |
|-------------------|-------------------|
| https://user-images.githubusercontent.com/6243712/195454552-e7a80280-8c8e-48ce-b987-1ddcee880e53.mp4 | https://user-images.githubusercontent.com/6243712/195454621-ab4c45b0-2273-4fb0-96b6-0f20593d0426.mp4 |